### PR TITLE
add trampoline interface

### DIFF
--- a/f4se/PluginAPI.h
+++ b/f4se/PluginAPI.h
@@ -23,6 +23,7 @@ enum
 	kInterface_Serialization,
 	kInterface_Task,
 	kInterface_Object,
+	kInterface_Trampoline,
 	kInterface_Max,
 };
 
@@ -210,6 +211,19 @@ struct F4SEObjectInterface
 	F4SEDelayFunctorManager & (* GetDelayFunctorManager)();
 	F4SEObjectRegistry & (* GetObjectRegistry)();
 	F4SEPersistentObjectStorage & (* GetPersistentObjectStorage)();
+};
+
+struct F4SETrampolineInterface
+{
+	enum
+	{
+		kInterfaceVersion = 1
+	};
+
+	UInt32	interfaceVersion;
+
+	void* (*AllocateFromBranchPool)(PluginHandle plugin, size_t size);
+	void* (*AllocateFromLocalPool)(PluginHandle plugin, size_t size);
 };
 
 struct PluginInfo

--- a/f4se/PluginManager.cpp
+++ b/f4se/PluginManager.cpp
@@ -103,15 +103,10 @@ namespace
 	{
 		assert(name != nullptr);
 
-		const auto mem = [](BranchTrampoline& alloc, size_t n) {
-			static std::mutex lock;
-			const auto guard = std::unique_lock<decltype(lock)>(lock);
-			return alloc.Allocate(n);
-		}(pool, size);
-
+		static std::mutex lock;
+		const auto guard = std::unique_lock<decltype(lock)>(lock);
+		const auto mem = pool.Allocate(size);
 		if (mem) {
-			static std::mutex lock;	// the global log isn't thread safe
-			const auto guard = std::unique_lock<decltype(lock)>(lock);
 			_DMESSAGE("plugin %u allocated %u bytes from %s pool", plugin, size, name);
 		}
 

--- a/f4se/PluginManager.h
+++ b/f4se/PluginManager.h
@@ -64,13 +64,14 @@ private:
 class PluginAllocator
 {
 public:
-	using Byte = unsigned char;
+	PluginAllocator()
+		:m_first(nullptr), m_last(nullptr) { }
 
-	Byte* Allocate(size_t n)
+	UInt8* Allocate(size_t n)
 	{
 		const Locker l(m_lock);
 
-		Byte* result = nullptr;
+		UInt8* result = nullptr;
 		if (m_first + n < m_last)
 		{
 			result = m_first;
@@ -84,17 +85,17 @@ public:
 	{
 		const Locker l(m_lock);
 		assert(!m_first && !m_last);
-		m_first = static_cast<Byte*>(memory);
+		m_first = static_cast<UInt8*>(memory);
 		m_last = m_first + size;
 	}
 
 private:
-	using Lock = std::mutex;
-	using Locker = std::lock_guard<Lock>;
+	typedef std::mutex Lock;
+	typedef std::lock_guard<Lock> Locker;
 
 	Lock m_lock;
-	Byte* m_first{ nullptr };
-	Byte* m_last{ nullptr };
+	UInt8* m_first;
+	UInt8* m_last;
 };
 
 extern PluginManager	g_pluginManager;


### PR DESCRIPTION
Note that by exposing the pool before we commit our hooks, we run the risk of a plugin allocating the entire pool before we can use it. The solution would be to move ` g_pluginManager.Init();` to the end, but this may or may not be a compatibility issue.
https://github.com/ianpatt/f4se/blob/14c99cbade4a077edea2eb1bc10fb98292cea0b8/f4se/f4se.cpp#L87-L98