### PR TITLE
Add new convenient command line options for developers

### DIFF
--- a/f4se_loader/Options.cpp
+++ b/f4se_loader/Options.cpp
@@ -15,6 +15,7 @@ Options::Options()
 	,m_launchSteam(false)
 	,m_noTimeout(false)
 	,m_forceSteamLoader(false)
+	,m_waitForDebugger(false)
 	,m_affinity(0)
 {
 	//
@@ -181,6 +182,10 @@ bool Options::Read(int argc, char ** argv)
 				{
 					m_forceSteamLoader = true;
 				}
+				else if (!_stricmp(arg, "waitfordebugger"))
+				{
+					m_waitForDebugger = true;
+				}
 				else
 				{
 					_ERROR("unknown switch (%s)", arg);
@@ -234,6 +239,7 @@ void Options::PrintUsage(void)
 	_MESSAGE("  -notimeout - don't automatically terminate the process if the proxy takes too long");
 	_MESSAGE("  -affinity <mask> - set the processor affinity mask");
 	_MESSAGE("  -forcesteamloader - override exe type detection and use steam loader");
+	_MESSAGE("  -waitfordebugger - wait for a debugger to attach before beginning execution");
 }
 
 bool Options::Verify(void)

--- a/f4se_loader/Options.h
+++ b/f4se_loader/Options.h
@@ -24,6 +24,7 @@ public:
 	bool	m_launchSteam;
 	bool	m_noTimeout;
 	bool	m_forceSteamLoader;
+	bool	m_waitForDebugger;
 
 	UInt64	m_affinity;
 

--- a/f4se_loader/main.cpp
+++ b/f4se_loader/main.cpp
@@ -34,11 +34,7 @@ void AugmentEnvironment(const std::string& procPath, const std::string& dllPath)
 
 	SetEnvironmentVariableA("F4SE_DLL", getFilename(dllPath).c_str());
 	SetEnvironmentVariableA("F4SE_RUNTIME", getFilename(procPath).c_str());
-
-	if (g_options.m_waitForDebugger)
-	{
-		SetEnvironmentVariableA("F4SE_WAITFORDEBUGGER", "1");
-	}
+	SetEnvironmentVariableA("F4SE_WAITFORDEBUGGER", (g_options.m_waitForDebugger ? "1" : "0"));
 }
 
 int main(int argc, char ** argv)

--- a/f4se_loader/main.cpp
+++ b/f4se_loader/main.cpp
@@ -18,6 +18,21 @@ IDebugLog gLog;
 static void PrintModuleInfo(UInt32 procID);
 static void PrintProcessInfo();
 
+void AugmentEnvironment(const std::string& procPath)
+{
+	{
+		std::vector<char> runtime(procPath.length() + 1, '\0');
+		std::copy(procPath.cbegin(), procPath.cend(), runtime.begin());
+		PathStripPathA(runtime.data());
+		SetEnvironmentVariableA("F4SE_RUNTIME", runtime.data());
+	}
+
+	if (g_options.m_waitForDebugger)
+	{
+		SetEnvironmentVariableA("F4SE_WAITFORDEBUGGER", "1");
+	}
+}
+
 int main(int argc, char ** argv)
 {
 	gLog.OpenRelative(CSIDL_MYDOCUMENTS, "\\My Games\\Fallout4\\F4SE\\f4se_loader.log");
@@ -220,13 +235,7 @@ int main(int argc, char ** argv)
 
 	startupInfo.cb = sizeof(startupInfo);
 
-	// augment environment
-	{
-		std::vector<char> runtime(procPath.length() + 1, '\0');
-		std::copy(procPath.cbegin(), procPath.cend(), runtime.begin());
-		PathStripPathA(runtime.data());
-		SetEnvironmentVariableA("F4SE_RUNTIME", runtime.data());
-	}
+	AugmentEnvironment(procPath);
 
 	if(!CreateProcess(
 		procPath.c_str(),

--- a/f4se_loader/main.cpp
+++ b/f4se_loader/main.cpp
@@ -7,6 +7,7 @@
 #include "f4se_loader_common/Inject.h"
 #include <algorithm>
 #include <string>
+#include <type_traits>
 #include <vector>
 #include "common/IFileStream.h"
 #include <Shlwapi.h>
@@ -18,14 +19,21 @@ IDebugLog gLog;
 static void PrintModuleInfo(UInt32 procID);
 static void PrintProcessInfo();
 
-void AugmentEnvironment(const std::string& procPath)
+void AugmentEnvironment(const std::string& procPath, const std::string& dllPath)
 {
-	{
-		std::vector<char> runtime(procPath.length() + 1, '\0');
-		std::copy(procPath.cbegin(), procPath.cend(), runtime.begin());
-		PathStripPathA(runtime.data());
-		SetEnvironmentVariableA("F4SE_RUNTIME", runtime.data());
-	}
+	const auto getFilename = [](const std::string& fullPath) {
+		char runtime[MAX_PATH] = { '\0' };
+		if (fullPath.length() < std::extent<decltype(runtime)>::value)
+		{
+			std::copy(fullPath.begin(), fullPath.end(), runtime);
+			PathStripPathA(runtime);
+		}
+
+		return std::string(runtime);
+	};
+
+	SetEnvironmentVariableA("F4SE_DLL", getFilename(dllPath).c_str());
+	SetEnvironmentVariableA("F4SE_RUNTIME", getFilename(procPath).c_str());
 
 	if (g_options.m_waitForDebugger)
 	{
@@ -235,7 +243,7 @@ int main(int argc, char ** argv)
 
 	startupInfo.cb = sizeof(startupInfo);
 
-	AugmentEnvironment(procPath);
+	AugmentEnvironment(procPath, dllPath);
 
 	if(!CreateProcess(
 		procPath.c_str(),

--- a/f4se_whatsnew.txt
+++ b/f4se_whatsnew.txt
@@ -2,6 +2,7 @@
 - fix ConstructibleComponent.object type
 - add a basic diagnosis for the dreaded error code 126
 - new interface for plugins to allocate from F4SE's branch-accessable pools
+- add new command line option "waitfordebugger" to explicitly wait for a debugger to attach regardless of build config
 
 0.6.21
 - fix Game.GetInstalledLightPlugins when more than 255 plugins are installed


### PR DESCRIPTION
* **skipversioncheck**: Sometimes Bethesda releases updates that only change the exe version, so it's nice to force load F4SE into binary compatible versions.
* **waitfordebugger**: Sometimes I just need to attach Cheat Engine, and I can't do that if I attach the VS debugger. Swapping the dll for the release build is kind of a pain.