### PR TITLE
Fixed script handle resolving

### DIFF
--- a/f4se/Serialization.cpp
+++ b/f4se/Serialization.cpp
@@ -305,7 +305,7 @@ namespace Serialization
 
 	bool ResolveHandle(UInt64 handle, UInt64 * handleOut)
 	{
-		UInt32	modID = handle >> 24;
+		UInt32	modID = (handle & 0xFF000000) >> 24;
 
 		if (modID == 0xFF)
 		{

--- a/f4se/Serialization.cpp
+++ b/f4se/Serialization.cpp
@@ -305,7 +305,7 @@ namespace Serialization
 
 	bool ResolveHandle(UInt64 handle, UInt64 * handleOut)
 	{
-		UInt8	modID = handle >> 24;
+		UInt32	modID = handle >> 24;
 
 		if (modID == 0xFF)
 		{


### PR DESCRIPTION
Fixed script handle resoliving when script defined in ESL plugin.

An example of script handle that could not be correctly resolved:
0x00000000**FE007**803