### PR TITLE
Update PapyrusArgs.h

### DIFF
--- a/f4se/PapyrusArgs.h
+++ b/f4se/PapyrusArgs.h
@@ -217,6 +217,11 @@ public:
 
 	void UnpackVariable(VMValue * value)
 	{
+		if (!value->data.var)
+		{
+			return;
+		}
+		
 		m_var = value->data.var;
 		m_value = *m_var;
 	}

--- a/f4se/PapyrusArgs.h
+++ b/f4se/PapyrusArgs.h
@@ -217,13 +217,16 @@ public:
 
 	void UnpackVariable(VMValue * value)
 	{
-		if (!value->data.var)
+		if (value->data.var)
 		{
-			return;
+			m_var = value->data.var;
+			m_value = *m_var;
 		}
-		
-		m_var = value->data.var;
-		m_value = *m_var;
+		else
+		{
+			m_var = nullptr;
+			m_value.SetNone();
+		}
 	}
 
 	bool IsNone()

--- a/f4se_whatsnew.txt
+++ b/f4se_whatsnew.txt
@@ -1,6 +1,7 @@
 0.6.24
 - ScriptObject.RegisterForGamepadButton and related
 - Form.GetEditorID
+- handle 'None' as an array member when passed to custom papyrus functions
 
 0.6.23
 - workaround for bug in High FPS Physics Fix


### PR DESCRIPTION
Without the fix CTD happens when user passed "NONE" value in an VMVariable array(VMArray<VMVariable>)

Example papyrus script to reproduce CTD:
Var[] TestArr = new Var[1]
TestArr[0] = None
UI.Invoke("Console","test",TestArr)