### PR TITLE
Fix offsets and typo in NiRTTI

### DIFF
--- a/f4se/NiExtraData.h
+++ b/f4se/NiExtraData.h
@@ -11,7 +11,7 @@ class NiExtraData : public NiObject
 public:
 	virtual ~NiExtraData() { };
 
-	virtual NiRTTI				* GetRTTI(void) override { return NIRTTI_NiExtraData; };
+	virtual NiRTTI				* GetRTTI(void) override { return NiRTTI_NiExtraData; };
 
 	virtual void				LoadBinary(void * stream) override { CALL_MEMBER_FN(this, Internal_LoadBinary)(stream); };
 	virtual void				SaveBinary(void * stream) override { CALL_MEMBER_FN(this, Internal_SaveBinary)(stream); };

--- a/f4se/NiRTTI.cpp
+++ b/f4se/NiRTTI.cpp
@@ -11,7 +11,7 @@ NiObject * DoNiRTTICast(NiObject * src, const NiRTTI * typeInfo)
 	return nullptr;
 }
 
-const RelocPtr<NiRTTI>	NiRTTI_BSLightingShaderProperty(0x03E47310);
-const RelocPtr<NiRTTI>	NiRTTI_BSEffectShaderProperty(0x03E47300);
-const RelocPtr<NiRTTI>	NiRTTI_BSShaderProperty(0x03E47298);
-const RelocPtr<NiRTTI>	NiRTTI_NiExtraData(0x03438040);
+const RelocPtr<NiRTTI>	NiRTTI_BSLightingShaderProperty(0x03E47390);
+const RelocPtr<NiRTTI>	NiRTTI_BSEffectShaderProperty(0x03E47380);
+const RelocPtr<NiRTTI>	NiRTTI_BSShaderProperty(0x03E47318);
+const RelocPtr<NiRTTI>	NiRTTI_NiExtraData(0x034380C0);

--- a/f4se/NiRTTI.h
+++ b/f4se/NiRTTI.h
@@ -19,4 +19,4 @@ NiObject * DoNiRTTICast(NiObject * src, const NiRTTI * typeInfo);
 extern const RelocPtr<NiRTTI>	NiRTTI_BSLightingShaderProperty;
 extern const RelocPtr<NiRTTI>	NiRTTI_BSEffectShaderProperty;
 extern const RelocPtr<NiRTTI>	NiRTTI_BSShaderProperty;
-extern const RelocPtr<NiRTTI>	NIRTTI_NiExtraData;
+extern const RelocPtr<NiRTTI>	NiRTTI_NiExtraData;


### PR DESCRIPTION
Thanks for the quick update, but the offsets in NiRTTI.cpp failed to be correctly updated again causing issues and crashes for LooksMenu. The correct offsets are as follows:

```
﻿const RelocPtr<NiRTTI>    NiRTTI_BSLightingShaderProperty(0x03E47390);
const RelocPtr<NiRTTI>    NiRTTI_BSEffectShaderProperty(0x03E47380);
const RelocPtr<NiRTTI>    NiRTTI_BSShaderProperty(0x03E47318);
const RelocPtr<NiRTTI>    NiRTTI_NiExtraData(0x034380C0);
```

Also NiRTTI_NiExtraData has been incorrectly capitalized in the NiRTTI.h header as NIRTTI_NiExtraData (note the first i in NiRTTI) 