### PR TITLE
GameObjects: Resolve operator ambiguity

### DIFF
--- a/f4se/GameObjects.h
+++ b/f4se/GameObjects.h
@@ -172,8 +172,9 @@ public:
 		UInt32	key;		// 00
 		float	value;		// 04
 
-		bool operator==(const UInt32 a_key) const	{ return key == a_key; }
-		operator UInt32() const						{ return key; }
+		bool operator==(const UInt32 a_key) const		{ return key == a_key; }
+		bool operator==(const MorphSetData & rhs) const	{ return key == rhs.key; }
+		operator UInt32() const							{ return key; }
 		static inline UInt32 GetHash(const UInt32 * key)
 		{
 			UInt32 hash;
@@ -194,8 +195,9 @@ public:
 		UInt32	index;		// 00
 		float	value[8];	// 04
 
-		bool operator==(const UInt32 a_key) const	{ return index == a_key; }
-		operator UInt32() const						{ return index; }
+		bool operator==(const UInt32 a_key) const			{ return index == a_key; }
+		bool operator==(const FaceMorphRegion & rhs) const	{ return index == rhs.index; }
+		operator UInt32() const								{ return index; }
 		static inline UInt32 GetHash(const UInt32 * key)
 		{
 			UInt32 hash;


### PR DESCRIPTION
This resolves a build error when trying to Add/Insert entries into `TESNPC::morphRegionData` or `TESNPC::morphSetData`:

```
f4se\f4se\GameTypes.h(1012): error C2666: 'TESNPC::MorphSetData::operator ==': overloaded functions have similar conversions
  f4se\f4se\GameObjects.h(175): note: could be 'bool TESNPC::MorphSetData::operator ==(const UInt32) const'
  f4se\f4se\GameObjects.h(175): note: or 'bool TESNPC::MorphSetData::operator ==(const UInt32) const' [synthesized expression 'y == x']
  f4se\f4se\GameTypes.h(1012): note: or       'built-in C++ operator==(UInt32, UInt32)'
  f4se\f4se\GameTypes.h(1012): note: while trying to match the argument list '(Item, Item)'
          with
          [
              Item=TESNPC::MorphSetData
          ]
  f4se\f4se\GameTypes.h(1012): note: the template instantiation context (the oldest one first) is
  f4ee\CharGenInterface.cpp(131): note: see reference to class template instantiation 'tHashSet<TESNPC::MorphSetData,UInt32>' being compiled
  f4se\f4se\GameTypes.h(988): note: while compiling class template member function 'tHashSet<TESNPC::MorphSetData,UInt32>::InsertResult tHashSet<TESNPC::MorphSetData,UInt32>::Insert(Item *)'
          with
          [
              Item=TESNPC::MorphSetData
          ]
  f4se\f4se\GameTypes.h(1163): note: see the first reference to 'tHashSet<TESNPC::MorphSetData,UInt32>::Insert' in 'tHashSet<TESNPC::MorphSetData,UInt32>::Add'
```